### PR TITLE
Improve job handling in printer controller

### DIFF
--- a/src/routes/controllerRoutes.ts
+++ b/src/routes/controllerRoutes.ts
@@ -74,29 +74,16 @@ router.get('/prints/parameterized/coin/getJobId', async (req, res) => {
 
 
 /**
- * GET `/prints/parameterized/coin/:coinJobId/status`
+ * GET `/prints/parameterized/coin/status`
  *
  * Returns the status of a running print job.
  *
- * @param req.params.coinJobId - ID of the coin job whose status is requested.
- *
  * @returns 200 - `JobStatus` object describing the current progress.
- * @returns 400 - `{ error: string }` when the `coinJobId` parameter is missing.
  * @returns 500 - `{ error: string }` on internal errors.
  */
-router.get('/prints/parameterized/coin/:coinJobId/status', async (req, res) => {
-    // 1) Pfad-Parameter auslesen
-    const { coinJobId } = req.params;
-
-     if (!coinJobId) {
-      return res
-        .status(400)
-        .json({ error: 'Missing required path parameter: coinJobId' });
-    }
-
+router.get('/prints/parameterized/coin/status', async (req, res) => {
     try {
-      // 2) Controller-Methode aufrufen
-      const status = await printerController.getPrintStatus(coinJobId);
+      const status = await printerController.getPrintStatus();
 
       // 3) Status-Objekt direkt zurückgeben
       return res.json(status);
@@ -112,27 +99,16 @@ router.get('/prints/parameterized/coin/:coinJobId/status', async (req, res) => {
 
 
 /**
- * PUT `/prints/parameterized/coin/:coinJobId/pause`
+ * PUT `/prints/parameterized/coin/pause`
  *
  * Pauses the running print job.
  *
- * @param req.params.coinJobId - ID of the job to pause.
- *
  * @returns 204 - When the job was paused successfully.
- * @returns 400 - `{ error: string }` when `coinJobId` is missing.
  * @returns 500 - `{ error: string }` on internal errors.
  */
-router.put('/prints/parameterized/coin/:coinJobId/pause', async (req, res) => {
-    const { coinJobId } = req.params;
-
-    if (!coinJobId) {
-      return res
-        .status(400)
-        .json({ error: 'Missing required path parameter: coinJobId' });
-    }
-
+router.put('/prints/parameterized/coin/pause', async (req, res) => {
     try {
-      await printerController.pausePrint(coinJobId);
+      await printerController.pausePrint();
       // Spec: 204 No Content
       return res.sendStatus(204);
     } catch (err: any) {
@@ -148,26 +124,16 @@ router.put('/prints/parameterized/coin/:coinJobId/pause', async (req, res) => {
 );
 
 /**
- * PUT `/prints/parameterized/coin/:coinJobId/resume`
+ * PUT `/prints/parameterized/coin/resume`
  *
  * Resumes a paused print job.
  *
- * @param req.params.coinJobId - ID of the job to resume.
- *
  * @returns 204 - When the job was resumed successfully.
- * @returns 400 - `{ error: string }` when `coinJobId` is missing.
  * @returns 500 - `{ error: string }` on internal errors.
  */
-router.put('/prints/parameterized/coin/:coinJobId/resume', async (req, res) => {
-    const { coinJobId } = req.params;
-    
-    if (!coinJobId) {
-          return res
-            .status(400)
-            .json({ error: 'Missing required path parameter: coinJobId' });
-        }  
+router.put('/prints/parameterized/coin/resume', async (req, res) => {
     try {
-          await printerController.resumePrint(coinJobId);
+          await printerController.resumePrint();
           return res
             .sendStatus(204);
         } catch (err: any) {
@@ -184,28 +150,17 @@ router.put('/prints/parameterized/coin/:coinJobId/resume', async (req, res) => {
 );
 
 /**
- * DELETE `/prints/parameterized/coin/:coinJobId/cancel`
+ * DELETE `/prints/parameterized/coin/cancel`
  *
  * Cancels a running print job.
  *
- * @param req.params.coinJobId - ID of the job to cancel.
- *
  * @returns 204 - When the job was cancelled successfully.
- * @returns 400 - `{ error: string }` when `coinJobId` is missing.
  * @returns 500 - `{ error: string }` on internal errors.
  */
-router.delete('/prints/parameterized/coin/:coinJobId/cancel', async (req, res) => {
-  const { coinJobId } = req.params;
-
-  if (!coinJobId) {
-    return res
-      .status(400)
-      .json({ error: 'Missing required path parameter: coinJobId' });
-  }
-
+router.delete('/prints/parameterized/coin/cancel', async (req, res) => {
   try {
-    await printerController.cancelPrint(coinJobId);
-    return res.sendStatus(204)
+    await printerController.cancelPrint();
+    return res.sendStatus(204);
   } catch (err: any) {
     console.error(
       '[ControllerRoutes] Error while cancelling print:',
@@ -214,8 +169,7 @@ router.delete('/prints/parameterized/coin/:coinJobId/cancel', async (req, res) =
     return res
       .status(500)
       .json({ error: err.message });
-    }
   }
-);
+});
 
 export default router;


### PR DESCRIPTION
## Summary
- track current job ID in `PrinterController`
- automatically store ID after starting a print
- allow status and control actions without providing an ID
- clear stored ID once a job finishes or gets canceled
- simplify controller routes so ID isn't required on API calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68428ea243d08329bf14e24eb5872a46