### PR TITLE
Handle config IDs for print

### DIFF
--- a/mock-config-server/callPrint.js
+++ b/mock-config-server/callPrint.js
@@ -3,7 +3,10 @@ import axios from 'axios';
 
 async function callPrint() {
   try {
-    const res = await axios.post('http://localhost:3000/api/prints/parameterized/coin');
+    const res = await axios.post('http://localhost:3000/api/prints/parameterized/coin', {
+      machineConfigID: 'example-machine',
+      configSetID: 'example-config'
+    });
     console.log(res.data);
   } catch (err) {
     console.error(err.message);

--- a/src/routes/controllerRoutes.ts
+++ b/src/routes/controllerRoutes.ts
@@ -22,10 +22,14 @@ const router = Router();
  */
 router.post('/prints/parameterized/coin', async (req, res) => {
   try {
-    
     const { machineConfigID, configSetID } = req.body;
+    if (!machineConfigID || !configSetID) {
+      return res
+        .status(400)
+        .json({ error: 'machineConfigID and configSetID are required' });
+    }
 
-    await printerController.startPrint();
+    await printerController.startPrint(machineConfigID, configSetID);
 
     return res.json({ message: 'Printing started successfully!' });
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- require machine and config set identifiers for starting prints
- fetch parameter data from config server using those IDs
- validate request parameters in controller route
- update sample script to include IDs

## Testing
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6853c9ed7d38832987fe37c2d73de3d9