### PR TITLE
Add coin print route tests

### DIFF
--- a/tests/coinPrintRoute.test.ts
+++ b/tests/coinPrintRoute.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+
+jest.mock('../src/controller/printerController');
+
+import { printerController } from '../src/controller/printerController';
+import { createTestApp } from './testUtils';
+
+const app = createTestApp();
+
+describe('POST /api/prints/parameterized/coin', () => {
+  it('returns 400 when parameters are missing', async () => {
+    const res = await request(app)
+      .post('/api/prints/parameterized/coin')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(printerController.startPrint).not.toHaveBeenCalled();
+  });
+
+  it('starts a print and returns job ID in Location header', async () => {
+    (printerController.startPrint as jest.Mock).mockResolvedValue('1234');
+
+    const res = await request(app)
+      .post('/api/prints/parameterized/coin')
+      .send({ machineConfigID: 'mc', configSetID: 'cs' });
+
+    expect(printerController.startPrint).toHaveBeenCalledWith('mc', 'cs');
+    expect(res.status).toBe(201);
+    expect(res.headers.location).toBe('1234');
+    expect(res.body).toEqual({ jobId: '1234' });
+  });
+
+  it('propagates errors with status 500', async () => {
+    (printerController.startPrint as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const res = await request(app)
+      .post('/api/prints/parameterized/coin')
+      .send({ machineConfigID: 'mc', configSetID: 'cs' });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/printerStatusRoute.test.ts
+++ b/tests/printerStatusRoute.test.ts
@@ -1,14 +1,11 @@
-import express from 'express';
 import request from 'supertest';
 
 jest.mock('../src/controller/printerController');
 
-import router from '../src/routes/controllerRoutes';
 import { printerController } from '../src/controller/printerController';
+import { createTestApp } from './testUtils';
 
-const app = express();
-app.use(express.json());
-app.use('/api', router);
+const app = createTestApp();
 
 describe('GET /api/printer/status', () => {
   it('returns mapped printer status', async () => {

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import router from '../src/routes/controllerRoutes';
+
+export function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', router);
+  return app;
+}


### PR DESCRIPTION
## Summary
- factor out Express app creation for tests
- add tests for printing route

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543d33ecdc83298ffbb39ba8f16a36