### PR TITLE
Refactor ParsedParams location

### DIFF
--- a/src/types/parsedParams.ts
+++ b/src/types/parsedParams.ts
@@ -1,0 +1,17 @@
+// src/types/parsedParams.ts
+
+/**
+ * Normalized parameters used for model placement calculations.
+ */
+export interface ParsedParams {
+  /** Selected filament material */
+  material: string;
+  /** List of model sizes in millimeters */
+  sizes: number[];
+  /** Horizontal spacing between models */
+  spacingX: number;
+  /** Vertical spacing between models */
+  spacingY: number;
+  /** Maximum number of columns when arranging models */
+  maxColumns: number;
+}

--- a/src/utilities/gcodeUtils.ts
+++ b/src/utilities/gcodeUtils.ts
@@ -1,6 +1,8 @@
 // src/utilities/gcodeUtils.ts
 import fs from 'fs';
 import path from 'path';
+import type { ParsedParams } from '../types/parsedParams';
+export type { ParsedParams } from '../types/parsedParams';
 
 export interface SnippetParams {
 
@@ -11,13 +13,6 @@ export interface GCodeParameters {
   [key: string]: string | number | boolean | any;
 }
 
-export interface ParsedParams {
-  material: string;
-  sizes: number[];
-  spacingX: number;
-  spacingY: number;
-  maxColumns: number;
-}
 
 /**
  * Validate that the template contains the `;; MODELS_PLACEHOLDER` marker.

--- a/src/utilities/modelPlacement.ts
+++ b/src/utilities/modelPlacement.ts
@@ -3,6 +3,8 @@
 import fs from 'fs';
 import path from 'path';
 import modelsMetadata from './models.json';
+import type { ParsedParams } from '../types/parsedParams';
+export type { ParsedParams } from '../types/parsedParams';
 
 
 export interface ModelMeta {
@@ -22,13 +24,6 @@ export interface Placement {
   offsetY: number;
 }
 
-export interface ParsedParams {
-  material: string;
-  sizes: number[];
-  spacingX: number;
-  spacingY: number;
-  maxColumns: number;
-}
 
 type ModelsConfig = Record<string, ModelMeta[]>;
 


### PR DESCRIPTION
## Summary
- move `ParsedParams` interface to new `src/types/parsedParams.ts`
- import and re-export the interface from `gcodeUtils` and `modelPlacement`

## Testing
- `npm test` *(fails: 1 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6855052f495c832998b72ec9760dcf0e