### PR TITLE
Add environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Dadurch wird eine Anfrage gesendet und das erwartete Verhalten getestet.
 - Node.js (empfohlen: die neueste LTS-Version)
 - Yarn als Paketmanager
 
+## Umgebungsvariablen
+
+Der Server liest bestimmte Einstellungen aus Umgebungsvariablen. Für die lokale
+Entwicklung werden folgende Standardwerte verwendet, falls keine Variablen
+gesetzt sind:
+
+- `CONFIG_SERVER_URL` – Basis-URL des Konfigurationsservers
+  (Standard: `http://localhost:3011`)
+- `PRUSALINK_URL` – Adresse der PrusaLink-Instanz
+  (Standard: `http://192.168.12.20`)
+- `PRUSALINK_API_KEY` – API-Schlüssel für PrusaLink
+  (Standard: `GGLfRCFkCEFXrEN`)
+
 ## API Endpoints
 
 ### `GET /api/printer/status`

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "eslint-plugin-prettier": "^5.4.0",
     "express": "^4.18.2",
     "form-data": "^4.0.2",
-    "handlebars": "^4.7.8"
+    "handlebars": "^4.7.8",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@types/axios": "^0.9.36",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,10 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const CONFIG_SERVER_URL =
+  process.env.CONFIG_SERVER_URL || 'http://localhost:3011';
+export const PRUSALINK_URL =
+  process.env.PRUSALINK_URL || 'http://192.168.12.20';
+export const PRUSALINK_API_KEY =
+  process.env.PRUSALINK_API_KEY || 'GGLfRCFkCEFXrEN';

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@
 import express, { Request, Response } from 'express';
 import controllerRoutes from './routes/controllerRoutes';
 import { errorHandler } from './middleware/errorHandler';
+import './config';
 
 
 /**

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import { ConfigServerResponse, ConfigParamDef } from '../types/configServer';
+import { CONFIG_SERVER_URL } from '../config';
 
 export class ConfigService {
   private baseUrl: string;
 
-  constructor(baseUrl = 'http://localhost:3011') {
+  constructor(baseUrl = CONFIG_SERVER_URL) {
     this.baseUrl = baseUrl;
   }
 

--- a/src/services/prusaLinkService.ts
+++ b/src/services/prusaLinkService.ts
@@ -1,13 +1,14 @@
 import axios from 'axios';
 import { JobStatus } from '../types/jobStatus';
+import { PRUSALINK_URL, PRUSALINK_API_KEY } from '../config';
 
 export class PrusaLinkService {
   private baseUrl: string;
   private apiKey: string;
 
   constructor(
-    baseUrl: string = process.env.PRUSALINK_URL || 'http://192.168.12.20',
-    apiKey: string = process.env.PRUSALINK_API_KEY || 'GGLfRCFkCEFXrEN'
+    baseUrl: string = PRUSALINK_URL,
+    apiKey: string = PRUSALINK_API_KEY
   ) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,6 +1545,11 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+dotenv@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.5.0.tgz#092b49f25f808f020050051d1ff258e404c78692"
+  integrity sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv`
- centralize configuration constants in a new `config.ts`
- use these constants in `ConfigService` and `PrusaLinkService`
- initialise config in `server.ts`
- document required environment variables in the README
- add `dotenv` dependency

## Testing
- `npx -y yarn@1 test`

------
https://chatgpt.com/codex/tasks/task_e_68550ef8f3408329a1013109e43b938d