### PR TITLE
Fix ConfigService constructor syntax error

### DIFF
--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -12,7 +12,7 @@ export class ConfigService {
   /**
    * @param baseUrl - Base URL of the config server.
    */
-  constructor(baseUrl = CONFIG_SERVER_URL) { {
+  constructor(baseUrl = CONFIG_SERVER_URL) {
 
     this.baseUrl = baseUrl;
   }


### PR DESCRIPTION
## Summary
- fix stray curly brace in `ConfigService` constructor
- all tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685511b9202c83298481ecf589c98b8f