### PR TITLE
Add printer status overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,19 @@ gcode/                      # G-code templates for logo or body
 ## API Endpoints
 
 ### `GET /api/printer/status`
-Returns the mapped printer status.
+Returns the mapped printer status. If the status was previously set via a
+`PUT /api/printer/status` request, the stored value is returned instead of the
+live value from PrusaLink.
 
 Example response:
 ```json
 { "status": "ready-for-print" }
 ```
+
+### `PUT /api/printer/status`
+Starts either the calibration or shutdown sequence based on the provided
+`status` body property. The value is then returned by subsequent
+`GET /api/printer/status` calls.
 
 Additional endpoints for starting, pausing and monitoring jobs are defined in [src/routes/controllerRoutes.ts](src/routes/controllerRoutes.ts).
 

--- a/src/controller/printerController.ts
+++ b/src/controller/printerController.ts
@@ -9,6 +9,7 @@ import { JobStatus } from '../types/jobStatus';
  */
 class PrinterController {
   private currentJobId?: string;
+  private overrideStatus?: 'start-up' | 'shutting-down';
 
   /**
    * Creates a new controller instance.
@@ -67,8 +68,10 @@ class PrinterController {
   public async updatePrinterStatus(status: 'start-up' | 'shutting-down'): Promise<void> {
     if (status === 'start-up') {
       await this.startCalibration();
+      this.overrideStatus = 'start-up';
     } else if (status === 'shutting-down') {
       await this.startShutdown();
+      this.overrideStatus = 'shutting-down';
     } else {
       throw new Error(`Invalid status: ${status}`);
     }
@@ -78,6 +81,9 @@ class PrinterController {
    * Retrieves the current status of the printer from PrusaLink.
    */
   public getPrinterStatus(): Promise<string> {
+    if (this.overrideStatus) {
+      return Promise.resolve(this.overrideStatus);
+    }
     return this.prusaLink.getPrinterStatus();
   }
 

--- a/tests/printerStatusOverrideRoute.test.ts
+++ b/tests/printerStatusOverrideRoute.test.ts
@@ -1,0 +1,44 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../src/controller/printerController', () => {
+  const { PrinterController } = jest.requireActual('../src/controller/printerController');
+  class StubPrusaLinkService {
+    uploadAndPrint = jest.fn().mockResolvedValue(undefined);
+    getCurrentJobId = jest.fn().mockResolvedValue(null);
+    getPrinterStatus = jest.fn().mockResolvedValue('from-prusa');
+    getPrintStatus = jest.fn();
+    pauseJob = jest.fn();
+    resumeJob = jest.fn();
+    cancelJob = jest.fn();
+  }
+  class StubGcodeService {
+    loadCalibrationGcode = jest.fn().mockResolvedValue('CAL');
+    loadShutdownGcode = jest.fn().mockResolvedValue('SHUT');
+  }
+  const controller = new PrinterController({}, new StubGcodeService() as any, new StubPrusaLinkService() as any);
+  return { printerController: controller, PrinterController };
+});
+
+import router from '../src/routes/controllerRoutes';
+
+const app = express();
+app.use(express.json());
+app.use('/api', router);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PUT then GET /api/printer/status integration', () => {
+  it('returns overridden status', async () => {
+    const putRes = await request(app)
+      .put('/api/printer/status')
+      .send({ status: 'start-up' });
+    expect(putRes.status).toBe(202);
+
+    const getRes = await request(app).get('/api/printer/status');
+    expect(getRes.status).toBe(200);
+    expect(getRes.body).toEqual({ status: 'start-up' });
+  });
+});


### PR DESCRIPTION
## Summary
- override printer status inside PrinterController
- expose override behaviour via GET `/api/printer/status`
- test that PUT `/api/printer/status` value persists when fetching status
- document new endpoint behaviour

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68598f1c07488329983984bad5e2d17f