### PR TITLE
Add printer status overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,20 @@ gcode/                      # G-code templates for logo or body
 ## API Endpoints
 
 ### `GET /api/printer/status`
-Returns the mapped printer status.
+Returns the mapped printer status. If the status was previously set via a
+`PUT /api/printer/status` request, that value is returned as long as the printer
+is still executing the job triggered by the call. Once the job ID changes, the
+live value from PrusaLink is served again.
 
 Example response:
 ```json
 { "status": "ready-for-print" }
 ```
+
+### `PUT /api/printer/status`
+Starts either the calibration or shutdown sequence based on the provided
+`status` body property. The chosen status is returned by `GET /api/printer/status`
+until a new job ID is detected, at which point normal status reporting resumes.
 
 Additional endpoints for starting, pausing and monitoring jobs are defined in [src/routes/controllerRoutes.ts](src/routes/controllerRoutes.ts).
 

--- a/tests/printerStatusOverrideRoute.test.ts
+++ b/tests/printerStatusOverrideRoute.test.ts
@@ -1,0 +1,61 @@
+import express from 'express';
+import request from 'supertest';
+
+let getCurrentJobIdMock: jest.Mock;
+jest.mock('../src/controller/printerController', () => {
+  const { PrinterController } = jest.requireActual('../src/controller/printerController');
+  getCurrentJobIdMock = jest.fn().mockResolvedValue('job1');
+  class StubPrusaLinkService {
+    uploadAndPrint = jest.fn().mockResolvedValue(undefined);
+    getCurrentJobId = getCurrentJobIdMock;
+    getPrinterStatus = jest.fn().mockResolvedValue('from-prusa');
+    getPrintStatus = jest.fn();
+    pauseJob = jest.fn();
+    resumeJob = jest.fn();
+    cancelJob = jest.fn();
+  }
+  class StubGcodeService {
+    loadCalibrationGcode = jest.fn().mockResolvedValue('CAL');
+    loadShutdownGcode = jest.fn().mockResolvedValue('SHUT');
+  }
+  const controller = new PrinterController({}, new StubGcodeService() as any, new StubPrusaLinkService() as any);
+  return { printerController: controller, PrinterController };
+});
+
+import router from '../src/routes/controllerRoutes';
+
+const app = express();
+app.use(express.json());
+app.use('/api', router);
+
+afterEach(() => {
+  jest.clearAllMocks();
+  getCurrentJobIdMock.mockResolvedValue('job1');
+});
+
+describe('PUT then GET /api/printer/status integration', () => {
+  it('returns overridden status', async () => {
+    const putRes = await request(app)
+      .put('/api/printer/status')
+      .send({ status: 'start-up' });
+    expect(putRes.status).toBe(202);
+
+    const getRes = await request(app).get('/api/printer/status');
+    expect(getRes.status).toBe(200);
+    expect(getRes.body).toEqual({ status: 'start-up' });
+  });
+
+  it('clears override when job id changes', async () => {
+    getCurrentJobIdMock.mockResolvedValueOnce('job1'); // startCalibration
+    getCurrentJobIdMock.mockResolvedValueOnce('job1'); // first GET
+    getCurrentJobIdMock.mockResolvedValueOnce('job2'); // second GET
+
+    await request(app).put('/api/printer/status').send({ status: 'start-up' });
+
+    const first = await request(app).get('/api/printer/status');
+    expect(first.body).toEqual({ status: 'start-up' });
+
+    const second = await request(app).get('/api/printer/status');
+    expect(second.body).toEqual({ status: 'from-prusa' });
+  });
+});


### PR DESCRIPTION
## Summary
- override printer status inside PrinterController
- expose override behaviour via GET `/api/printer/status`
- test that PUT `/api/printer/status` value persists when fetching status
- document new endpoint behaviour

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68598f1c07488329983984bad5e2d17f