### PR TITLE
Change height input to mm

### DIFF
--- a/src/utilities/flattenConfigParameters.ts
+++ b/src/utilities/flattenConfigParameters.ts
@@ -8,11 +8,11 @@ import { ConfigParamDef } from '../types/configServer';
  */
 const MODEL_SIZES = [20, 23.25, 25.75, 30];
 
-/** Base coin thickness in centimeters */
-const BASE_HEIGHT_CM = 0.21;
+/** Base coin thickness in millimeters */
+const BASE_HEIGHT_MM = 2.1;
 
-/** Maximum supported coin thickness in centimeters */
-const MAX_HEIGHT_CM = 0.5;
+/** Maximum supported coin thickness in millimeters */
+const MAX_HEIGHT_MM = 5;
 
 /**
  * Return the model size closest to the provided value.
@@ -59,14 +59,14 @@ export function flattenConfigParameters(
   // 3) height
   const height = params['height'];
   if (height?.content.length) {
-    // height is specified in centimeters
-    const heightCm = Number(height.content[0].value);
+    // height is specified in millimeters
+    const heightMm = Number(height.content[0].value);
     // clamp to supported range
-    const clampedCm = Math.min(Math.max(heightCm, BASE_HEIGHT_CM), MAX_HEIGHT_CM);
+    const clampedMm = Math.min(Math.max(heightMm, BASE_HEIGHT_MM), MAX_HEIGHT_MM);
     // difference from base height in mm
-    const additionalMm = (clampedCm - BASE_HEIGHT_CM) * 10;
+    const additionalMm = clampedMm - BASE_HEIGHT_MM;
     // each layer is 0.2 mm high
-    const layers = Math.round(additionalMm / 0.2);
+    const layers = Math.round(additionalMm / 0.2 + 1e-6);
     result.LAYERS = layers;
   }
   

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -13,7 +13,7 @@ describe('flattenConfigParameters', () => {
         },
       },
       width: { content: [{ value: 20 }, { value: 25 }], parameters: {} },
-      height: { content: [{ value: 1 }], parameters: {} },
+      height: { content: [{ value: 10 }], parameters: {} },
       'top-surface': {
         content: [],
         parameters: {
@@ -68,9 +68,9 @@ describe('flattenConfigParameters', () => {
     expect(result.MODEL_SIZE).toEqual([30]);
   });
 
-  it('clamps height at 0.5 cm when converting to layers', () => {
+  it('clamps height at 5 mm when converting to layers', () => {
     const params: Record<string, ConfigParamDef> = {
-      height: { content: [{ value: 10 }], parameters: {} },
+      height: { content: [{ value: 100 }], parameters: {} },
     } as any;
 
     const result = flattenConfigParameters(params);


### PR DESCRIPTION
## Summary
- use mm for coin thickness calculations
- test new mm-based parsing

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685bec74098483299e09996724846176