### PR TITLE
Handle shutdown temperature cooldown

### DIFF
--- a/tests/printerStatusRoute.test.ts
+++ b/tests/printerStatusRoute.test.ts
@@ -9,13 +9,16 @@ const app = createTestApp();
 
 describe('GET /api/printer/status', () => {
   it('returns mapped printer status', async () => {
-    (printerController.getPrinterStatus as jest.Mock).mockResolvedValue('ready-for-print');
+    (printerController.getPrinterStatus as jest.Mock).mockResolvedValue({
+      status: 'ready-for-print',
+      temp_bed: 55,
+    });
 
     const res = await request(app).get('/api/printer/status');
 
     expect(printerController.getPrinterStatus).toHaveBeenCalled();
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ready-for-print' });
+    expect(res.body).toEqual({ status: 'ready-for-print', temp_bed: 55 });
   });
 
   it('handles failures with 500', async () => {


### PR DESCRIPTION
## Summary
- preserve shutdown status while the bed is hot
- check bed temperature only once in `getPrinterStatus`
- adjust printer status route tests for returned temperature
- add integration test covering shutdown cooldown behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c4d5d8ee483298f2ed4bad7e7e089