### PR TITLE
Add missing unit tests

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,28 @@
+describe('config module', () => {
+  const env = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env };
+    delete process.env.CONFIG_SERVER_URL;
+    delete process.env.PRUSALINK_URL;
+    delete process.env.PRUSALINK_API_KEY;
+  });
+  afterAll(() => {
+    process.env = env;
+  });
+
+  it('uses environment variables when provided', () => {
+    process.env.CONFIG_SERVER_URL = 'http://c';
+    process.env.PRUSALINK_URL = 'http://p';
+    process.env.PRUSALINK_API_KEY = 'KEY';
+    const cfg = require('../src/config');
+    expect(cfg.CONFIG_SERVER_URL).toBe('http://c');
+    expect(cfg.PRUSALINK_URL).toBe('http://p');
+    expect(cfg.PRUSALINK_API_KEY).toBe('KEY');
+  });
+
+  it('falls back to defaults', () => {
+    const cfg = require('../src/config');
+    expect(cfg.CONFIG_SERVER_URL).toMatch('research.snet.tu-berlin.de');
+  });
+});

--- a/tests/configService.test.ts
+++ b/tests/configService.test.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { ConfigService } from '../src/services/configService';
+import type { ConfigServerResponse } from '../src/types/configServer';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('ConfigService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches parameters from the config server', async () => {
+    const response: ConfigServerResponse = { metadata: { name: 'm' }, parameters: { a: { content: [], parameters: {} } } };
+    mockedAxios.get.mockResolvedValue({ data: response } as any);
+    const service = new ConfigService('http://config');
+    const result = await service.fetchParameters('machine', 'set');
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'http://config/api/spaces/proceed-default-no-iam-user/configurations/set/latest/machine/machine'
+    );
+    expect(result).toEqual(response.parameters);
+  });
+});

--- a/tests/gcodeService.test.ts
+++ b/tests/gcodeService.test.ts
@@ -1,0 +1,67 @@
+import { GcodeService } from '../src/services/gcodeService';
+import { GCodeTransformer } from '../src/transformer/gcodeTransformer';
+import * as fs from 'fs';
+import path from 'path';
+
+jest.mock('../src/transformer/gcodeTransformer');
+
+const readFileMock = jest.spyOn(fs.promises, 'readFile');
+const writeFileMock = jest.spyOn(fs.promises, 'writeFile');
+
+describe('GcodeService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates final gcode based on filament type', async () => {
+    readFileMock.mockResolvedValue('TEMPLATE');
+    writeFileMock.mockResolvedValue();
+
+    const transformer = new GCodeTransformer() as unknown as jest.Mocked<GCodeTransformer>;
+    (transformer.transformGCode as jest.Mock).mockResolvedValue('FINAL');
+
+    const service = new GcodeService(transformer);
+    const params: any = {
+      'coin-color': {
+        content: [],
+        parameters: {
+          'coin-material': { content: [{ value: 'PLA' }], parameters: {} },
+          'coin-printing-head-no': { content: [], parameters: {} },
+        },
+      },
+    };
+
+    const result = await service.createFinalGcode(params);
+
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join('parameterized_g-code', 'PLA_start_G-code.gcode')),
+      'utf-8'
+    );
+    expect(transformer.transformGCode).toHaveBeenCalledWith('TEMPLATE', params);
+    expect(writeFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join('parameterized_g-code', 'final.gcode')),
+      'FINAL',
+      'utf-8'
+    );
+    expect(result).toBe('FINAL');
+  });
+
+  it('loads calibration and shutdown gcode', async () => {
+    readFileMock.mockResolvedValueOnce('CAL');
+    const service = new GcodeService(new GCodeTransformer() as any);
+    const cal = await service.loadCalibrationGcode();
+    expect(cal).toBe('CAL');
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join('gcode', 'printer_control', 'start-up.gcode')),
+      'utf-8'
+    );
+
+    readFileMock.mockResolvedValueOnce('SHUT');
+    const shut = await service.loadShutdownGcode();
+    expect(shut).toBe('SHUT');
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join('gcode', 'printer_control', 'shutting-down.gcode')),
+      'utf-8'
+    );
+  });
+});

--- a/tests/handlebarsHelpers.test.ts
+++ b/tests/handlebarsHelpers.test.ts
@@ -1,0 +1,34 @@
+import handlebars from 'handlebars';
+import { registerHandlebarsHelpers } from '../src/helpers/handlebarsHelpers';
+
+describe('handlebars helpers', () => {
+  beforeAll(() => {
+    registerHandlebarsHelpers();
+  });
+
+  it('getData returns element at index', () => {
+    const tpl = handlebars.compile('{{getData "sizes" params 1}}');
+    const out = tpl({ params: { sizes: [10, 20, 30] } });
+    expect(out).toBe('20');
+  });
+
+  it('repeat provides index variable', () => {
+    const tpl = handlebars.compile('{{#repeat 3}}{{index}}{{/repeat}}');
+    expect(tpl({})).toBe('012');
+  });
+
+  it('calcZ and shiftZ compute values', () => {
+    const tpl = handlebars.compile('{{calcZ 2 "0.2" "0.1"}} {{shiftZ "0.8" 3 "0.2"}}');
+    expect(tpl({})).toBe('0.400 1.200');
+  });
+
+  it('insertValues inserts numbers at positions', () => {
+    const tpl = handlebars.compile('{{insertValues 0 1.1 2 2.2}}');
+    expect(tpl({})).toBe('1.1, 0.00, 2.2, 0.00, 0.00');
+  });
+
+  it('offHeaters generates commands', () => {
+    const tpl = handlebars.compile('{{offHeaters 0 2}}');
+    expect(tpl({})).toBe('M104 T1 S0\nM104 T3 S0\nM104 T4 S0\n');
+  });
+});

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,36 @@
+import { asyncHandler } from '../src/middleware/asyncHandler';
+import { errorHandler } from '../src/middleware/errorHandler';
+
+describe('asyncHandler', () => {
+  it('forwards resolved values', async () => {
+    const req: any = {};
+    const res: any = { send: jest.fn() };
+    const next = jest.fn();
+    const wrapped = asyncHandler(async () => { res.send('ok'); });
+    await wrapped(req, res, next);
+    expect(res.send).toHaveBeenCalledWith('ok');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('forwards errors', async () => {
+    const err = new Error('boom');
+    const next = jest.fn();
+    const wrapped = asyncHandler(async () => { throw err; });
+    await wrapped({} as any, {} as any, next);
+    expect(next).toHaveBeenCalledWith(err);
+  });
+});
+
+describe('errorHandler', () => {
+  it('formats error responses', () => {
+    const log = jest.spyOn(console, 'error').mockImplementation();
+    const req: any = { method: 'GET', path: '/x' };
+    const res: any = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const err = new Error('oops');
+    errorHandler(err, req, res, jest.fn());
+    expect(log).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'oops' });
+    log.mockRestore();
+  });
+});

--- a/tests/modelPlacement.test.ts
+++ b/tests/modelPlacement.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import { loadModels, calculateLayout, insertModelBlocks } from '../src/utilities/modelPlacement';
+import type { ParsedParams } from '../src/types/parsedParams';
+
+const readFileMock = jest.spyOn(fs.promises, 'readFile');
+
+describe('modelPlacement utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads models from disk', async () => {
+    readFileMock.mockResolvedValue('MODEL');
+    const parsed: ParsedParams = { material: 'PETG', sizes: [20], spacingX: 0, spacingY: 0, maxColumns: 1 };
+    const models = await loadModels(parsed);
+    expect(readFileMock).toHaveBeenCalledWith(expect.stringContaining('20.00mm.gcode'), 'utf8');
+    expect(models[0].meta.size).toBe(20);
+    expect(models[0].content).toBe('MODEL');
+  });
+
+  it('throws when model entry is missing', async () => {
+    const parsed: ParsedParams = { material: 'PETG', sizes: [99], spacingX: 0, spacingY: 0, maxColumns: 1 };
+    await expect(loadModels(parsed)).rejects.toThrow('No block for PETG 99mm');
+  });
+
+  it('calculates layout and detects collisions', () => {
+    const models = [
+      { meta: { size: 1, path: '', boundingBox: { width: 10, depth: 10 } }, content: 'A' },
+      { meta: { size: 1, path: '', boundingBox: { width: 10, depth: 10 } }, content: 'B' },
+    ];
+    const parsed: ParsedParams = { material: 'PETG', sizes: [], spacingX: 20, spacingY: 20, maxColumns: 2 };
+    const layout = calculateLayout(models, parsed);
+    expect(layout[1].offsetX).toBe(20);
+
+    const badParsed: ParsedParams = { material: 'PETG', sizes: [], spacingX: 5, spacingY: 5, maxColumns: 1 };
+    expect(() => calculateLayout(models, badParsed)).toThrow('Collision detected');
+  });
+
+  it('inserts model blocks into template', () => {
+    const template = 'START\n;; MODELS_PLACEHOLDER\nEND';
+    const placements = [
+      { model: { meta: { size: 1, path: '', boundingBox: { width: 1, depth: 1 } }, content: 'A' }, offsetX: 0, offsetY: 0 },
+      { model: { meta: { size: 1, path: '', boundingBox: { width: 1, depth: 1 } }, content: 'B' }, offsetX: 10, offsetY: 10 },
+    ];
+    const result = insertModelBlocks(template, placements, 'L');
+    expect(result).toBe('START\nA\nL\nB\nL\nEND');
+  });
+});

--- a/tests/prusaLinkService.test.ts
+++ b/tests/prusaLinkService.test.ts
@@ -1,0 +1,68 @@
+import axios from 'axios';
+import { PrusaLinkService } from '../src/services/prusaLinkService';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('PrusaLinkService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uploads gcode with auth headers', async () => {
+    mockedAxios.put.mockResolvedValue({} as any);
+    const service = new PrusaLinkService('http://p', 'KEY');
+    await service.uploadAndPrint('G');
+    expect(mockedAxios.put).toHaveBeenCalled();
+    const [url, buf, opts] = mockedAxios.put.mock.calls[0];
+    expect(url).toBe('http://p/api/v1/files/usb/Vlad_Tests/final.gcode');
+    expect((buf as Buffer).toString()).toBe('G');
+    expect(opts?.headers?.['X-Api-Key']).toBe('KEY');
+    expect(opts?.headers?.['Print-After-Upload']).toBe('?1');
+  });
+
+  it('gets current job id', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 204 } as any);
+    const service = new PrusaLinkService('b', 'k');
+    expect(await service.getCurrentJobId()).toBeNull();
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: { id: 7 } } as any);
+    expect(await service.getCurrentJobId()).toBe('7');
+  });
+
+  it('maps printer status and handles errors', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: { printer: { state: 'FINISHED', temp_bed: 40 } } } as any);
+    const service = new PrusaLinkService('b', 'k');
+    const ready = await service.getPrinterStatus();
+    expect(ready).toEqual({ status: 'ready-for-print', temp_bed: 40 });
+
+    mockedAxios.get.mockRejectedValueOnce(new Error('off'));
+    const fail = await service.getPrinterStatus();
+    expect(fail).toEqual({ status: 'printer-not-reachable', temp_bed: 0 });
+  });
+
+  it('returns job status information', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 204 } as any);
+    const service = new PrusaLinkService('b', 'k');
+    const finished = await service.getPrintStatus('1');
+    expect(finished).toEqual({ id: 1, state: 'finished', progress: 100, timePrinting: 0, timeRemaining: 0 });
+
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: { id: 2, state: 'printing', progress: 10, time_printing: 5, time_remaining: 5 },
+    } as any);
+    const job = await service.getPrintStatus('2');
+    expect(job).toEqual({ id: 2, state: 'printing', progress: 10, timePrinting: 5, timeRemaining: 5 });
+  });
+
+  it('sends pause, resume and cancel requests', async () => {
+    mockedAxios.put.mockResolvedValue({} as any);
+    mockedAxios.delete.mockResolvedValue({} as any);
+    const service = new PrusaLinkService('b', 'k');
+    await service.pauseJob('1');
+    expect(mockedAxios.put).toHaveBeenCalledWith('b/api/v1/job/1/pause', null, { headers: { 'X-Api-Key': 'k' } });
+    await service.resumeJob('1');
+    expect(mockedAxios.put).toHaveBeenCalledWith('b/api/v1/job/1/resume', null, { headers: { 'X-Api-Key': 'k' } });
+    await service.cancelJob('1');
+    expect(mockedAxios.delete).toHaveBeenCalledWith('b/api/v1/job/1', { headers: { 'X-Api-Key': 'k' } });
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,23 @@
+const use = jest.fn();
+const get = jest.fn();
+const listen = jest.fn();
+
+const router = { post: jest.fn(), get: jest.fn(), put: jest.fn(), delete: jest.fn() };
+
+jest.mock('express', () => {
+  const expressFn: any = jest.fn(() => ({ use, get, listen }));
+  expressFn.Router = jest.fn(() => router);
+  expressFn.json = jest.fn(() => () => {});
+  expressFn.urlencoded = jest.fn(() => () => {});
+  return expressFn;
+});
+
+describe('server entrypoint', () => {
+  it('initializes express app and routes', async () => {
+    process.env.PORT = '1234';
+    await import('../src/server');
+    expect(use).toHaveBeenCalledWith('/api', router);
+    expect(get).toHaveBeenCalledWith('/health', expect.any(Function));
+    expect(listen).toHaveBeenCalledWith('1234', expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for ConfigService and PrusaLinkService
- cover GcodeService, model placement utilities and middleware helpers
- test Handlebars helpers and configuration values
- verify server entrypoint wiring

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685e47139774832983f60db71942a97f