### PR TITLE
Validate coordinate range

### DIFF
--- a/src/utilities/flattenConfigParameters.ts
+++ b/src/utilities/flattenConfigParameters.ts
@@ -114,11 +114,21 @@ export function flattenConfigParameters(
     const x = coords.parameters['x'];
     const y = coords.parameters['y'];
     if (x?.content.length) {
-      result.POS_X = Number(x.content[0].value);
+      const val = Number(x.content[0].value);
+      if (val >= 0 && val <= 330) {
+        result.POS_X = val;
+      } else {
+        result.POS_X = Number(defaultParams.POS_X);
+      }
     }
     if (y?.content.length) {
-      result.POS_Y = Number(y.content[0].value);
-    } 
+      const val = Number(y.content[0].value);
+      if (val >= 0 && val <= 330) {
+        result.POS_Y = val;
+      } else {
+        result.POS_Y = Number(defaultParams.POS_Y);
+      }
+    }
   }
 
   return result;

--- a/tests/utilities.test.ts
+++ b/tests/utilities.test.ts
@@ -102,6 +102,22 @@ describe('flattenConfigParameters', () => {
     expect(result.FIRST_PRINTING_HEAD).toBe(0);
     expect(result.SECOND_PRINTING_HEAD).toBe(0);
   });
+
+  it('uses default coordinates when values are out of range', () => {
+    const params: Record<string, ConfigParamDef> = {
+      coordinates: {
+        content: [],
+        parameters: {
+          x: { content: [{ value: 400 }], parameters: {} },
+          y: { content: [{ value: -10 }], parameters: {} },
+        },
+      },
+    } as any;
+
+    const result = flattenConfigParameters(params);
+    expect(result.POS_X).toBe(0);
+    expect(result.POS_Y).toBe(0);
+  });
 });
 
 describe('parseParams', () => {


### PR DESCRIPTION
## Summary
- validate that coordinates from config are between 0 and 330
- default coordinates to config defaults when values are invalid
- test the new coordinate validation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e52f0e8d083299f2a7177eaddbede