### PR TITLE
Add final gcode loader

### DIFF
--- a/src/services/gcodeService.ts
+++ b/src/services/gcodeService.ts
@@ -67,4 +67,21 @@ export class GcodeService {
     const shutdownPath = path.join(process.cwd(), 'gcode', 'printer_control', 'shutting-down.gcode');
     return fs.readFile(shutdownPath, 'utf-8');
   }
+
+  /**
+   * Loads the final generated G-code from disk if present.
+   *
+   * @returns The final G-code contents or `null` when the file does not exist.
+   */
+  async loadFinalGcode(): Promise<string | null> {
+    const finalPath = path.join(process.cwd(), 'gcode', 'print_ready', 'final.gcode');
+    try {
+      return await fs.readFile(finalPath, 'utf-8');
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') {
+        return null;
+      }
+      throw err;
+    }
+  }
 }

--- a/tests/gcodeService.test.ts
+++ b/tests/gcodeService.test.ts
@@ -64,4 +64,27 @@ describe('GcodeService', () => {
       'utf-8'
     );
   });
+
+  it('loads final gcode when present', async () => {
+    readFileMock.mockResolvedValueOnce('FINAL');
+    const service = new GcodeService(new GCodeTransformer() as any);
+    const final = await service.loadFinalGcode();
+    expect(final).toBe('FINAL');
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join('gcode', 'print_ready', 'final.gcode')),
+      'utf-8'
+    );
+  });
+
+  it('returns null when final gcode is missing', async () => {
+    const enoent = Object.assign(new Error('no'), { code: 'ENOENT' });
+    readFileMock.mockRejectedValueOnce(enoent);
+    const service = new GcodeService(new GCodeTransformer() as any);
+    const final = await service.loadFinalGcode();
+    expect(final).toBeNull();
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join('gcode', 'print_ready', 'final.gcode')),
+      'utf-8'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- provide function to load `gcode/print_ready/final.gcode`
- test loading the file and ENOENT handling

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e83db3bd88329bc40fb66b9f484e6