### PR TITLE
Implement fallback to last or default G-code

### DIFF
--- a/src/services/gcodeService.ts
+++ b/src/services/gcodeService.ts
@@ -38,7 +38,9 @@ export class GcodeService {
    * @returns Rendered G-code ready for printing.
    */
   async createFinalGcode(rawParams: Record<string, ConfigParamDef>): Promise<string> {
-    const filamentType = rawParams["coin-color"].parameters["coin-material"].content[0].value || 'PETG';
+    const filamentType =
+      rawParams?.["coin-color"]?.parameters?.["coin-material"]?.content?.[0]?.value ||
+      'PETG';
     const templateFile = this.getTemplateFile(String(filamentType));
 
     const gcodeFilePath = path.join(process.cwd(), 'gcode', 'templates', templateFile);

--- a/tests/printerController.test.ts
+++ b/tests/printerController.test.ts
@@ -1,0 +1,65 @@
+import { PrinterController } from '../src/controller/printerController';
+
+describe('PrinterController.startPrint', () => {
+  const makePrusa = () => ({
+    uploadAndPrint: jest.fn().mockResolvedValue(undefined),
+    getCurrentJobId: jest.fn().mockResolvedValue('42'),
+    getPrinterStatus: jest.fn(),
+    getPrintStatus: jest.fn(),
+    pauseJob: jest.fn(),
+    resumeJob: jest.fn(),
+    cancelJob: jest.fn(),
+  });
+
+  it('uses config parameters when fetch succeeds', async () => {
+    const cfg = { fetchParameters: jest.fn().mockResolvedValue({ a: 1 }) } as any;
+    const gcode = {
+      createFinalGcode: jest.fn().mockResolvedValue('NEW'),
+      loadFinalGcode: jest.fn(),
+    } as any;
+    const prusa = makePrusa();
+    const controller = new PrinterController(cfg, gcode, prusa as any);
+
+    const id = await controller.startPrint('m', 'c');
+
+    expect(cfg.fetchParameters).toHaveBeenCalledWith('m', 'c');
+    expect(gcode.createFinalGcode).toHaveBeenCalledWith({ a: 1 });
+    expect(gcode.loadFinalGcode).not.toHaveBeenCalled();
+    expect(prusa.uploadAndPrint).toHaveBeenCalledWith('NEW');
+    expect(id).toBe('42');
+  });
+
+  it('falls back to last gcode when config fetch fails', async () => {
+    const cfg = { fetchParameters: jest.fn().mockRejectedValue(new Error('fail')) } as any;
+    const gcode = {
+      createFinalGcode: jest.fn(),
+      loadFinalGcode: jest.fn().mockResolvedValue('OLD'),
+    } as any;
+    const prusa = makePrusa();
+    const controller = new PrinterController(cfg, gcode, prusa as any);
+
+    const id = await controller.startPrint('m', 'c');
+
+    expect(gcode.loadFinalGcode).toHaveBeenCalled();
+    expect(gcode.createFinalGcode).not.toHaveBeenCalled();
+    expect(prusa.uploadAndPrint).toHaveBeenCalledWith('OLD');
+    expect(id).toBe('42');
+  });
+
+  it('generates gcode from defaults when no file is found', async () => {
+    const cfg = { fetchParameters: jest.fn().mockRejectedValue(new Error('fail')) } as any;
+    const gcode = {
+      createFinalGcode: jest.fn().mockResolvedValue('NEW'),
+      loadFinalGcode: jest.fn().mockResolvedValue(null),
+    } as any;
+    const prusa = makePrusa();
+    const controller = new PrinterController(cfg, gcode, prusa as any);
+
+    const id = await controller.startPrint('m', 'c');
+
+    expect(gcode.loadFinalGcode).toHaveBeenCalled();
+    expect(gcode.createFinalGcode).toHaveBeenCalledWith({});
+    expect(prusa.uploadAndPrint).toHaveBeenCalledWith('NEW');
+    expect(id).toBe('42');
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing coin-color configuration when generating G-code
- retry printing using previous final.gcode or defaults if config server fails
- cover new logic with printer controller tests

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e87279a688329b6bfe26c666c9c3e